### PR TITLE
Extracted filename from track path

### DIFF
--- a/src/MpdClient.cpp
+++ b/src/MpdClient.cpp
@@ -132,6 +132,10 @@ std::string createArtist(mpd_song_t* song)
     RET_CLAMP_STRSTREAM(stream);
 }
 
+std::string extractFileName(const std::string& fullPath)
+{
+  return fullPath.substr(fullPath.find_last_of("/\\") + 1);
+}
 
 TrackInfo MpdClient::getCurrentTrack()
 {
@@ -150,7 +154,7 @@ TrackInfo MpdClient::getCurrentTrack()
     t.TrackNumber = mpd_status_get_song_pos(mpdStatus) + 1;
     t.PlayTimeSeconds = mpd_status_get_elapsed_time(mpdStatus);
     t.Artist = createArtist(mpdCurrentSong);
-    t.TrackName = createTitle(mpdCurrentSong);
+    t.TrackName = extractFileName(createTitle(mpdCurrentSong));
     
     mpd_song_free(mpdCurrentSong);
     mpd_status_free(mpdStatus);


### PR DESCRIPTION
The presence description uses the track name directly from mpd, which in some cases may be a full path (relative to mpd's library root), this would often get cropped off by discord, making the description not useful. Changed to only show the filename instead of full path. 